### PR TITLE
Make `Window` class a singleton.

### DIFF
--- a/minesweeper/src/Constants.h
+++ b/minesweeper/src/Constants.h
@@ -8,6 +8,10 @@ const int MAX_COLUMN = 30;
 const int MAX_ROW = 30;
 
 
+// WINDOW
+const sf::VideoMode DEFAULT_WINDOW_SIZE = sf::VideoMode(1500, 1000);
+
+
 // TEXT
 const int DEFAULT_FONT_SIZE = 23;
 const int DEFAULT_TITLE_FONT_SIZE = DEFAULT_FONT_SIZE * 4.5;
@@ -36,7 +40,7 @@ const float DEFAULT_CELL_AREA = DEFAULT_CELL_SIZE;// +(DEFAULT_CELL_SIZE / (floa
 const sf::Vector2f TOP_LEFT_COEF_BOARD_AREA = sf::Vector2f(0, 0);
 const sf::Vector2f RIGHT_DOWN_COEF_BOARD_AREA = sf::Vector2f(4 / (float)5, 1);
 const sf::Vector2f POS_COEF_TIMER = sf::Vector2f(4 / (float)5, 1 / (float)3);
-const sf::Vector2f POS_COEF_HIGHSCORE = sf::Vector2f(4 / (float)5, 2 / (float)5);
+const sf::Vector2f POS_COEF_record = sf::Vector2f(4 / (float)5, 2 / (float)5);
 
 
 // IMAGE PATHS

--- a/minesweeper/src/Window/Window.cpp
+++ b/minesweeper/src/Window/Window.cpp
@@ -7,6 +7,9 @@
 #include "../Board/Board.h"
 
 
+Window* Window::instance = nullptr;
+
+
 sf::Vector2i Window::getMousePosition() const {
 	return pos_mouse;
 }
@@ -59,6 +62,14 @@ void Window::setCurrentSceneType(const SceneType& type) {
 }
 
 
+std::shared_ptr<Window*> Window::getInstance() {
+	if (!instance) {
+		instance = new Window();
+	}
+	return std::make_shared<Window*>(instance);
+}
+
+
 void Window::createWindow() {
 	render_window.create(window_size, title, window_style);
 }
@@ -66,6 +77,30 @@ void Window::createWindow() {
 
 void Window::closeWindow() {
 	render_window.close();
+}
+
+
+bool Window::handleSfEvent(const sf::Event& event) {
+	bool change = false;
+
+	switch (event.type) {
+	case sf::Event::Closed:
+		change |= handleGameEvents(GameEvent::QuitGame);
+		break;
+	case sf::Event::MouseMoved:
+		change |= changeMousePosition(sf::Vector2i(event.mouseMove.x, event.mouseMove.y));
+		break;
+	case sf::Event::MouseButtonPressed:
+		change |= handleMouseButtonPress(event.mouseButton.button, sf::Vector2i(event.mouseButton.x, event.mouseButton.y));
+		break;
+	case sf::Event::MouseButtonReleased:
+		change |= handleMouseButtonRelease(event.mouseButton.button, sf::Vector2i(event.mouseButton.x, event.mouseButton.y));
+		break;
+	default:
+		break;
+	}
+
+	return change;
 }
 
 
@@ -160,13 +195,11 @@ bool Window::handleGameEvents(const GameEvent game_event) {
 		case GameEvent::Won:
 		{
 			// Load whole board, splash screen etc.
-			current_scene_type = SceneType::Won;
 			break;
 		}
 		case GameEvent::Lost: 
 		{
 			// Load whole board, splash screen etc.
-			current_scene_type = SceneType::Lost;
 			break;
 		}
 		case GameEvent::ClosePopUp:
@@ -281,6 +314,11 @@ void Window::draw(Button& button, const bool isHovered) {
 		draw(button.getHoveredSprite());
 
 	draw(button.label);
+}
+
+
+Result Window::updateGameInfo(const Comms::GameInfo info) {
+	return Result::failure;
 }
 
 

--- a/minesweeper/src/minesweeper.cpp
+++ b/minesweeper/src/minesweeper.cpp
@@ -65,62 +65,35 @@ void registerResources() {
 int main() {
     registerResources();
 
-    Window window(sf::VideoMode(1500, 1000), "minesweeper");
-    window.createWindow();
+    auto window = Window::getInstance();
 
-    sf::VideoMode window_size = sf::VideoMode(window.render_window.getSize().x, window.render_window.getSize().y, sf::Style::Close);
+    (*window)->initializeMenuScene();
+    (*window)->initializePlayingScene(30, 30);
 
-    window.initializeMenuScene();
-    window.initializePlayingScene(30, 30);
-
-    window.setCurrentSceneType(SceneType::Menu);
-
+    (*window)->createWindow();
     bool change = true;
-    while (window.render_window.isOpen()) {
+
+    while ((*window)->render_window.isOpen()) {
         sf::Event event;
 
-        while (window.render_window.pollEvent(event)) {
-            if (event.type == sf::Event::Closed)
-                window.closeWindow();
-
-            switch (event.type) {
-            case sf::Event::Closed:
-                window.closeWindow();
-                break;
-            case sf::Event::LostFocus:
-                break;
-            case sf::Event::GainedFocus:
-                break;
-
-            case sf::Event::MouseMoved:
-                change |= window.changeMousePosition(sf::Vector2i(event.mouseMove.x, event.mouseMove.y));
-                break;
-            case sf::Event::MouseButtonPressed:
-                change |= window.handleMouseButtonPress(event.mouseButton.button, sf::Vector2i(event.mouseButton.x, event.mouseButton.y));
-                break;
-            case sf::Event::MouseButtonReleased:
-                change |= window.handleMouseButtonRelease(event.mouseButton.button, sf::Vector2i(event.mouseButton.x, event.mouseButton.y));
-                break;
-            default:
-                break;
-            }
-        }
-
-        switch (window.getLastGameEvent()) {
-        case GameEvent::QuitGame:
-        {
-            window.closeWindow();
-            break;
-        }
-
-        default:
-            break;
+        while ((*window)->render_window.pollEvent(event)) {
+            change |= (*window)->handleSfEvent(event);
         }
 
         if (change) {
-            window.render_window.clear();
-            window.drawCurrentScene();
-            window.render_window.display();
+            (*window)->render_window.clear();
+            (*window)->drawCurrentScene();
+            (*window)->render_window.display();
+        }
+
+        switch ((*window)->getLastGameEvent()) {
+        case GameEvent::QuitGame:
+        {
+            (*window)->closeWindow();
+            break;
+        }
+        default:
+            break;
         }
 
         change = false;


### PR DESCRIPTION
Because `Window` class represents the entire interface of the game, there should only be one instance of it.
Besides, this would make merging code easier later on.