### PR TITLE
Optimize drawing method (cont.)

### DIFF
--- a/minesweeper/src/Interface/Background/Background.cpp
+++ b/minesweeper/src/Interface/Background/Background.cpp
@@ -180,14 +180,12 @@ void Background::setNextConfig(const AudioVisualCfg::Cfg& cfg) {
 void Background::draw(std::shared_ptr<sf::RenderTarget> renderer, const bool is_focusing) {
 	renderer->draw(background);
 
-	sf::CircleShape shape;
-
 	for (auto& circle : circles) {
-		shape.setRadius(circle.radius);
-		shape.setOrigin(circle.radius, circle.radius);
-		shape.setFillColor(cur_second_color);
-		shape.setPosition(circle.pos);
+		circle_shape.setRadius(circle.radius);
+		circle_shape.setOrigin(circle.radius, circle.radius);
+		circle_shape.setFillColor(cur_second_color);
+		circle_shape.setPosition(circle.pos);
 		
-		renderer->draw(shape);
+		renderer->draw(circle_shape);
 	}
 }

--- a/minesweeper/src/Interface/Background/Background.h
+++ b/minesweeper/src/Interface/Background/Background.h
@@ -36,6 +36,7 @@ private:
 	float circle_speed;
 
 	sf::RectangleShape background;
+	sf::CircleShape circle_shape;
 	std::vector <Circle> circles;
 
 	sf::Clock clock;

--- a/minesweeper/src/Interface/Scenes/playing_scene.cpp
+++ b/minesweeper/src/Interface/Scenes/playing_scene.cpp
@@ -246,8 +246,6 @@ Position PlayingScene::getLastPressedCell() const {
 
 
 void PlayingScene::draw(std::shared_ptr<sf::RenderTarget> renderer, const bool is_focusing) {
-	sf::Sprite sprite;
-
 	for (int i = 0; i < board.number_of_rows; i++) {
 		for (int j = 0; j < board.number_of_cols; j++) {
 			if (is_focusing && Position(i, j) == board.hovered_cell) {

--- a/minesweeper/src/Interface/Scenes/scene.cpp
+++ b/minesweeper/src/Interface/Scenes/scene.cpp
@@ -151,9 +151,6 @@ SceneType Scene::getNextScene(const GameEvent game_event) const {
 
 
 void Scene::draw(std::shared_ptr<sf::RenderTarget> renderer, const bool is_focusing) {
-	sf::Sprite sprite;
-	sf::Text text;
-
 	bool is_focusing_on_current = is_focusing;
 	if (pop_up)
 		is_focusing_on_current = false;

--- a/minesweeper/src/Interface/Scenes/scene.h
+++ b/minesweeper/src/Interface/Scenes/scene.h
@@ -20,6 +20,8 @@ class Scene {
 protected:
 	const std::string STR_UNKNOWN = "unknown";
 	const std::string STR_NEXT_SONG = "next_song";
+	sf::Sprite sprite;
+	sf::Text text;
 
 	SceneType scene_type;
 	sf::VideoMode window_size;

--- a/minesweeper/src/Interface/Slider/Slider.cpp
+++ b/minesweeper/src/Interface/Slider/Slider.cpp
@@ -129,17 +129,14 @@ void Slider::setSliderPercentValue(const float new_percent_value) {
 
 
 void Slider::draw(std::shared_ptr<sf::RenderTarget> renderer, const bool is_focusing) {
-	sf::Sprite sprite;
-	sf::Text text;
+	loadText(sfText, top_left_pos.x - 10, top_left_pos.y + 5, std::to_string(min_value), 20);
+	renderer->draw(sfText);
 
-	loadText(text, top_left_pos.x - 10, top_left_pos.y + 5, std::to_string(min_value), 20);
-	renderer->draw(text);
+	loadText(sfText, top_left_pos.x + axis.getSize().x - 10, top_left_pos.y + 5, std::to_string(max_value), 20);
+	renderer->draw(sfText);
 
-	loadText(text, top_left_pos.x + axis.getSize().x - 10, top_left_pos.y + 5, std::to_string(max_value), 20);
-	renderer->draw(text);
-
-	loadText(text, slider.getPosition().x - slider.getSize().x, slider.getPosition().y - slider.getSize().y, std::to_string((int)slider_value), 15);
-	renderer->draw(text);
+	loadText(sfText, slider.getPosition().x - slider.getSize().x, slider.getPosition().y - slider.getSize().y, std::to_string((int)slider_value), 15);
+	renderer->draw(sfText);
 
 	renderer->draw(axis);
 	renderer->draw(slider);

--- a/minesweeper/src/Interface/Slider/Slider.h
+++ b/minesweeper/src/Interface/Slider/Slider.h
@@ -10,6 +10,8 @@
 
 class Slider {
 private:
+	sf::Text sfText;
+
 	sf::RectangleShape slider;
 	sf::RectangleShape axis;
 	Text text;


### PR DESCRIPTION
There is now only one instance of `sf::Sprite` and `sf::Text` used in each scene.